### PR TITLE
Don't pass kwargs to fetch() when giving it an HTTPRequest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - unset CONDA_ENV_PATH # because the older conda in miniconda sets this, confusing some tests
   - export PATH=`echo "$PATH" | sed -e s@"$HOME"/miniconda/bin:@@g`
   - printenv | sort
-  - pip install coverage flake8 pep257 pytest pytest-cov yapf==0.6.2 beautifulsoup4 tornado pytest-xdist
+  - pip install coverage flake8==2.6.2 pep257 pytest pytest-cov yapf==0.6.2 beautifulsoup4 tornado pytest-xdist
   - conda install -y -q -c conda-forge keyring
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ test_script:
   - "%CONDA_ROOT%\\Scripts\\activate test-environment"
   - echo CONDA_PREFIX %CONDA_PREFIX%
   - echo PATH %PATH%
-  - pip install pep257 yapf==0.6.2 pytest-xdist flake8
+  - pip install pep257 yapf==0.6.2 pytest-xdist flake8==2.6.2
   - conda install -y -q -c conda-forge keyring
   - conda list
   - conda info -a

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - psutil # needed by conda
     - tornado
     - "backports_abc >=0.4" # required by tornado, not pulled in automatically?
+    - singledispatch
     - ruamel_yaml
     - beautifulsoup4
     - requests

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - setuptools
     - psutil # needed by conda
     - tornado
-    - "backports_abc >=0.4" # required by tornado, not pulled in automatically?
+    - "backports_abc >=0.4" # [py2k]
     - singledispatch
     - ruamel_yaml
     - beautifulsoup4

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - setuptools
     - psutil # needed by conda
     - tornado
+    - "backports_abc >=0.4" # required by tornado, not pulled in automatically?
     - ruamel_yaml
     - beautifulsoup4
     - requests

--- a/conda_kapsel/internal/http_client.py
+++ b/conda_kapsel/internal/http_client.py
@@ -93,7 +93,7 @@ class FileDownloader(object):
                                              streaming_callback=writer,
                                              request_timeout=timeout_in_seconds)
             try:
-                response = yield self._client.fetch(request, request_timeout=timeout_in_seconds)
+                response = yield self._client.fetch(request)
             except Exception as e:
                 self._errors.append("Failed download to %s: %s" % (self._filename, str(e)))
                 raise gen.Return(None)

--- a/conda_kapsel/internal/test/tmpfile_utils.py
+++ b/conda_kapsel/internal/test/tmpfile_utils.py
@@ -31,6 +31,10 @@ class TmpDir(object):
             # prefer original exception to rmtree exception
             if value is None:
                 print("Exception cleaning up TmpDir %s: %s" % (self._dir, str(e)), file=sys.stderr)
+                try:
+                    print("Files in %s: %r" % (self._dir, os.listdir(self._dir)), file=sys.stderr)
+                except Exception:
+                    pass
                 raise e
             else:
                 print("Failed to clean up TmpDir %s: %s" % (self._dir, str(e)), file=sys.stderr)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 import codecs
 import errno
+import multiprocessing
 import os
 import platform
 import re
@@ -92,7 +93,6 @@ if os.getenv('TRAVIS') == "true":
     CPU_COUNT = 2
 else:
     try:
-        import multiprocessing
         CPU_COUNT = multiprocessing.cpu_count()
     except Exception:
         print("Using fallback CPU count", file=sys.stderr)
@@ -524,6 +524,8 @@ class CondaPackageCommand(Command):
 
         print("Packages in " + self.packages_dir)
 
+
+multiprocessing.freeze_support()
 
 setup(name='conda-kapsel',
       version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['beautifulsoup4 >= 4.3', 'tornado >= 4.2', 'keyring >= 9.0']
 
-TEST_REQUIRES = ['coverage', 'flake8', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
+TEST_REQUIRES = ['coverage', 'flake8>=3.0.1', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')
@@ -324,7 +324,7 @@ class AllTestsCommand(TestCommand):
         assert [] == processes
 
     def _flake8(self):
-        from flake8.engine import get_style_guide
+        from flake8.api.legacy import get_style_guide
         flake8_style = get_style_guide(paths=self._git_staged_or_all_py_files(),
                                        max_line_length=120,
                                        ignore=[

--- a/setup.py
+++ b/setup.py
@@ -525,25 +525,26 @@ class CondaPackageCommand(Command):
         print("Packages in " + self.packages_dir)
 
 
-multiprocessing.freeze_support()
+if __name__ == '__main__':
+    multiprocessing.freeze_support()
 
-setup(name='conda-kapsel',
-      version=VERSION,
-      author="Continuum Analytics",
-      author_email='info@continuum.io',
-      url='http://github.com/Anaconda-Server/conda-kapsel',
-      description='Library to load and manipulate project directories',
-      license='New BSD',
-      zip_safe=False,
-      install_requires=REQUIRES,
-      tests_require=TEST_REQUIRES,
-      cmdclass=dict(test=AllTestsCommand,
-                    conda_package=CondaPackageCommand,
-                    version_module=VersionModuleCommand),
-      scripts=[
-          'bin/conda-kapsel'
-      ],
-      packages=[
-          'conda_kapsel', 'conda_kapsel.internal', 'conda_kapsel.commands', 'conda_kapsel.plugins',
-          'conda_kapsel.plugins.providers', 'conda_kapsel.plugins.requirements'
-      ])
+    setup(name='conda-kapsel',
+          version=VERSION,
+          author="Continuum Analytics",
+          author_email='info@continuum.io',
+          url='http://github.com/Anaconda-Server/conda-kapsel',
+          description='Library to load and manipulate project directories',
+          license='New BSD',
+          zip_safe=False,
+          install_requires=REQUIRES,
+          tests_require=TEST_REQUIRES,
+          cmdclass=dict(test=AllTestsCommand,
+                        conda_package=CondaPackageCommand,
+                        version_module=VersionModuleCommand),
+          scripts=[
+              'bin/conda-kapsel'
+          ],
+          packages=[
+              'conda_kapsel', 'conda_kapsel.internal', 'conda_kapsel.commands', 'conda_kapsel.plugins',
+              'conda_kapsel.plugins.providers', 'conda_kapsel.plugins.requirements'
+          ])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 
 import codecs
 import errno
-import multiprocessing
 import os
 import platform
 import re
@@ -61,7 +60,7 @@ PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['beautifulsoup4 >= 4.3', 'tornado >= 4.2', 'keyring >= 9.0']
 
-TEST_REQUIRES = ['coverage', 'flake8>=3.0.1', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
+TEST_REQUIRES = ['coverage', 'flake8', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')
@@ -93,6 +92,7 @@ if os.getenv('TRAVIS') == "true":
     CPU_COUNT = 2
 else:
     try:
+        import multiprocessing
         CPU_COUNT = multiprocessing.cpu_count()
     except Exception:
         print("Using fallback CPU count", file=sys.stderr)
@@ -324,7 +324,7 @@ class AllTestsCommand(TestCommand):
         assert [] == processes
 
     def _flake8(self):
-        from flake8.api.legacy import get_style_guide
+        from flake8.engine import get_style_guide
         flake8_style = get_style_guide(paths=self._git_staged_or_all_py_files(),
                                        max_line_length=120,
                                        ignore=[
@@ -525,26 +525,23 @@ class CondaPackageCommand(Command):
         print("Packages in " + self.packages_dir)
 
 
-if __name__ == '__main__':
-    multiprocessing.freeze_support()
-
-    setup(name='conda-kapsel',
-          version=VERSION,
-          author="Continuum Analytics",
-          author_email='info@continuum.io',
-          url='http://github.com/Anaconda-Server/conda-kapsel',
-          description='Library to load and manipulate project directories',
-          license='New BSD',
-          zip_safe=False,
-          install_requires=REQUIRES,
-          tests_require=TEST_REQUIRES,
-          cmdclass=dict(test=AllTestsCommand,
-                        conda_package=CondaPackageCommand,
-                        version_module=VersionModuleCommand),
-          scripts=[
-              'bin/conda-kapsel'
-          ],
-          packages=[
-              'conda_kapsel', 'conda_kapsel.internal', 'conda_kapsel.commands', 'conda_kapsel.plugins',
-              'conda_kapsel.plugins.providers', 'conda_kapsel.plugins.requirements'
-          ])
+setup(name='conda-kapsel',
+      version=VERSION,
+      author="Continuum Analytics",
+      author_email='info@continuum.io',
+      url='http://github.com/Anaconda-Server/conda-kapsel',
+      description='Library to load and manipulate project directories',
+      license='New BSD',
+      zip_safe=False,
+      install_requires=REQUIRES,
+      tests_require=TEST_REQUIRES,
+      cmdclass=dict(test=AllTestsCommand,
+                    conda_package=CondaPackageCommand,
+                    version_module=VersionModuleCommand),
+      scripts=[
+          'bin/conda-kapsel'
+      ],
+      packages=[
+          'conda_kapsel', 'conda_kapsel.internal', 'conda_kapsel.commands', 'conda_kapsel.plugins',
+          'conda_kapsel.plugins.providers', 'conda_kapsel.plugins.requirements'
+      ])

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['beautifulsoup4 >= 4.3', 'tornado >= 4.2', 'keyring >= 9.0']
 
-TEST_REQUIRES = ['coverage', 'flake8', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
+TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')


### PR DESCRIPTION
This fixes things with tornado 4.4, which throws an exception
if we do this incorrectly.
