### PR TITLE
Add an url-friendly name field to Project

### DIFF
--- a/conda_kapsel/internal/py2_compat.py
+++ b/conda_kapsel/internal/py2_compat.py
@@ -12,6 +12,13 @@ import sys
 _PY2 = sys.version_info[0] == 2
 
 
+def is_unicode(s):
+    if _PY2:  # pragma: no cover (py2/py3)
+        return isinstance(s, unicode)  # pragma: no cover (py2/py3) # noqa
+    else:  # pragma: no cover (py2/py3)
+        return isinstance(s, str)  # pragma: no cover (py2/py3)
+
+
 def is_string(s):
     if _PY2:  # pragma: no cover (py2/py3)
         return isinstance(s, basestring)  # pragma: no cover (py2/py3) # noqa

--- a/conda_kapsel/internal/slugify.py
+++ b/conda_kapsel/internal/slugify.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function
+
+import re
+
+_remove_chars = re.compile('[^A-Za-z0-9-_]')
+
+
+def slugify(s):
+    """A simple slugifier.
+
+    This keeps ascii alphanumerics, -, and _, but replaces
+    everything else with hyphen.
+    """
+    return re.sub(_remove_chars, '-', s)

--- a/conda_kapsel/internal/slugify.py
+++ b/conda_kapsel/internal/slugify.py
@@ -23,4 +23,16 @@ def slugify(s):
     if not is_unicode(s):
         # normalize() requires a unicode string
         s = s.decode(encoding='utf-8', errors='replace')
-    return re.sub(_remove_chars, '-', unicodedata.normalize('NFC', s))
+    s = unicodedata.normalize('NFC', s)
+
+    # Using `re.sub(_remove_chars, '-', s)` results in
+    # a different number of hyphens on OS X vs. Linux,
+    # maybe due to some Python re code confusing bytes vs. chars?
+    # So we manually do our own replacement.
+    def replace(c):
+        if _remove_chars.match(c):
+            return "-"
+        else:
+            return c
+
+    return "".join(map(replace, s))

--- a/conda_kapsel/internal/slugify.py
+++ b/conda_kapsel/internal/slugify.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, print_function
 
 import re
 
-_remove_chars = re.compile('[^A-Za-z0-9-_]')
+_remove_chars = re.compile('[^A-Za-z0-9-_]', re.UNICODE)
 
 
 def slugify(s):

--- a/conda_kapsel/internal/slugify.py
+++ b/conda_kapsel/internal/slugify.py
@@ -6,7 +6,10 @@
 # ----------------------------------------------------------------------------
 from __future__ import absolute_import, print_function
 
+from conda_kapsel.internal.py2_compat import is_unicode
+
 import re
+import unicodedata
 
 _remove_chars = re.compile('[^A-Za-z0-9-_]', re.UNICODE)
 
@@ -17,4 +20,7 @@ def slugify(s):
     This keeps ascii alphanumerics, -, and _, but replaces
     everything else with hyphen.
     """
-    return re.sub(_remove_chars, '-', s)
+    if not is_unicode(s):
+        # normalize() requires a unicode string
+        s = s.decode(encoding='utf-8', errors='replace')
+    return re.sub(_remove_chars, '-', unicodedata.normalize('NFC', s))

--- a/conda_kapsel/internal/test/test_slugify.py
+++ b/conda_kapsel/internal/test/test_slugify.py
@@ -19,7 +19,7 @@ def test_replace_spaces():
 
 
 def test_replace_unicode():
-    assert "-" == slugify("🌟")
+    assert "-" == slugify(u"🌟")
 
 
 def test_replace_specials():

--- a/conda_kapsel/internal/test/test_slugify.py
+++ b/conda_kapsel/internal/test/test_slugify.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function, unicode_literals
+
+from conda_kapsel.internal.slugify import slugify
+
+
+def test_should_be_unchanged():
+    s = "abcdefgxyz_ABCDEFGXYZ-0123456789"
+    assert s == slugify(s)
+
+
+def test_replace_spaces():
+    assert "a-b" == slugify("a b")
+
+
+def test_replace_unicode():
+    assert "-" == slugify("🌟")
+
+
+def test_replace_specials():
+    assert "-----------------" == slugify("!@#$%^&*()<>\"':/\\")

--- a/conda_kapsel/internal/test/test_slugify.py
+++ b/conda_kapsel/internal/test/test_slugify.py
@@ -24,3 +24,7 @@ def test_replace_unicode():
 
 def test_replace_specials():
     assert "-----------------" == slugify("!@#$%^&*()<>\"':/\\")
+
+
+def test_replace_bytes():
+    assert "-" == slugify(u"🌟".encode('utf-8'))

--- a/conda_kapsel/project.py
+++ b/conda_kapsel/project.py
@@ -23,6 +23,7 @@ from conda_kapsel.archiver import _list_relative_paths_for_unignored_project_fil
 
 from conda_kapsel.internal.py2_compat import is_string
 from conda_kapsel.internal.simple_status import SimpleStatus
+from conda_kapsel.internal.slugify import slugify
 import conda_kapsel.internal.conda_api as conda_api
 import conda_kapsel.internal.pip_api as pip_api
 
@@ -667,12 +668,17 @@ class Project(object):
 
     @property
     def name(self):
-        """Get the project name.
+        """Get the project's human-readable name.
 
         Prefers in order: `name` field from kapsel.yml, `package:
         name:` from meta.yaml, then project directory name.
         """
         return self._updated_cache().name
+
+    @property
+    def url_friendly_name(self):
+        """Get the project's url-friendly name."""
+        return slugify(self.name)
 
     @property
     def description(self):
@@ -806,6 +812,10 @@ class Project(object):
         """
         json = dict()
         json['name'] = self.name
+        # the recipient will have to validate this; including it here
+        # mostly because we might eventually allow the kapsel.yml to
+        # manually provide it.
+        json['url_friendly_name'] = self.url_friendly_name
         json['description'] = self.description
         commands = dict()
         for key, command in self.commands.items():

--- a/conda_kapsel/test/test_project.py
+++ b/conda_kapsel/test/test_project.py
@@ -40,6 +40,7 @@ def test_properties():
         assert dirname == os.path.dirname(project.project_file.filename)
         assert dirname == os.path.dirname(os.path.dirname(project.conda_meta_file.filename))
         assert project.name == os.path.basename(dirname)
+        assert project.url_friendly_name == os.path.basename(dirname)
         assert project.description == ''
 
     with_directory_contents(dict(), check_properties)
@@ -1891,6 +1892,7 @@ def test_get_publication_info_from_empty_project():
         project = project_no_dedicated_env(dirname)
         expected = {
             'name': os.path.basename(dirname),
+            'url_friendly_name': os.path.basename(dirname),
             'description': '',
             'commands': {},
             'env_specs': {
@@ -1915,7 +1917,7 @@ env_specs:
 
 
 _complicated_project_contents = """
-name: foobar
+name: foo bar
 description: "A very complicated project."
 
 commands:
@@ -1970,7 +1972,8 @@ def test_get_publication_info_from_complex_project():
         project = project_no_dedicated_env(dirname)
 
         expected = {
-            'name': 'foobar',
+            'name': 'foo bar',
+            'url_friendly_name': 'foo-bar',
             'description': 'A very complicated project.',
             'commands': {'bar': {'description': 'echo boo',
                                  'env_spec': 'lol',


### PR DESCRIPTION
This is autogenerated by slugifying the name for now, but in the future
it could be customizable via the project config file, if that turns
out to be useful.
