### PR TITLE
Implement environment.yml import on project creation and ongoing

### DIFF
--- a/conda_kapsel/commands/project_load.py
+++ b/conda_kapsel/commands/project_load.py
@@ -17,15 +17,15 @@ def load_project(dirname):
     project = Project(dirname)
 
     if console_utils.stdin_is_interactive():
-        fixed_any = False
         for problem in project.fixable_problems:
             print(problem.text)
             should_fix = console_utils.console_ask_yes_or_no(problem.fix_prompt, default=False)
             if should_fix:
                 problem.fix(project)
-                fixed_any = True
+            else:
+                problem.no_fix(project)
 
-        if fixed_any:
-            project.project_file.save()
+        # no-op if the fixes didn't do anything
+        project.project_file.save()
 
     return project

--- a/conda_kapsel/env_spec.py
+++ b/conda_kapsel/env_spec.py
@@ -7,10 +7,15 @@
 """Environment class representing a conda environment."""
 from __future__ import absolute_import
 
+import codecs
+import difflib
 import os
 
 import conda_kapsel.internal.conda_api as conda_api
 import conda_kapsel.internal.pip_api as pip_api
+from conda_kapsel.internal.py2_compat import is_string
+
+from conda_kapsel.yaml_file import _load_string, _YAMLError
 
 
 class EnvSpec(object):
@@ -31,6 +36,7 @@ class EnvSpec(object):
         self._channels = tuple(channels)
         self._pip_packages = tuple(pip_packages)
         self._description = description
+        self._channels_and_packages_hash = None
 
     @property
     def name(self):
@@ -44,6 +50,25 @@ class EnvSpec(object):
             return self._name
         else:
             return self._description
+
+    @property
+    def channels_and_packages_hash(self):
+        """Get a hash of our channels and packages.
+
+        This is used to see if they have changed. Order matters
+        (change in order will count as a change).
+        """
+        if self._channels_and_packages_hash is None:
+            import hashlib
+            m = hashlib.sha1()
+            for p in self.conda_packages:
+                m.update(p.encode("utf-8"))
+            for p in self.pip_packages:
+                m.update(p.encode("utf-8"))
+            for c in self.channels:
+                m.update(c.encode("utf-8"))
+            self._channels_and_packages_hash = m.hexdigest()
+        return self._channels_and_packages_hash
 
     @property
     def conda_packages(self):
@@ -79,3 +104,90 @@ class EnvSpec(object):
     def path(self, project_dir):
         """The filesystem path to the default conda env containing our packages."""
         return os.path.join(project_dir, "envs", self.name)
+
+    def diff_from(self, old):
+        """A string showing the comparison between this env spec and another one."""
+        channels_diff = list(difflib.ndiff(old.channels, self.channels))
+        conda_diff = list(difflib.ndiff(old.conda_packages, self.conda_packages))
+        pip_diff = list(difflib.ndiff(old.pip_packages, self.pip_packages))
+        if pip_diff:
+            pip_diff = ["  pip:"] + list(map(lambda x: "    " + x, pip_diff))
+        if channels_diff:
+            channels_diff = ["  channels:"] + list(map(lambda x: "    " + x, channels_diff))
+        return "\n".join(channels_diff + conda_diff + pip_diff)
+
+    def to_json(self):
+        """Get JSON for a kapsel.yml env spec section."""
+        packages = list(self.conda_packages)
+        pip_packages = list(self.pip_packages)
+        if pip_packages:
+            packages.append(dict(pip=pip_packages))
+        channels = list(self.channels)
+        return dict(packages=packages, channels=channels)
+
+
+def _load_environment_yml(filename):
+    """Load an environment.yml as an EnvSpec, or None if not loaded."""
+    try:
+        with codecs.open(filename, 'r', 'utf-8') as file:
+            contents = file.read()
+        yaml = _load_string(contents)
+    except (IOError, _YAMLError) as e:
+        return None
+
+    name = None
+    if 'name' in yaml:
+        name = yaml['name']
+    if not name:
+        if 'prefix' in yaml and yaml['prefix']:
+            name = os.path.basename(yaml['prefix'])
+
+    if not name:
+        name = os.path.basename(filename)
+
+    # We don't do too much validation here because we end up doing it
+    # later if we import this into the project, and then load it from
+    # the project file. We will do the import such that we don't end up
+    # keeping the new project file if it's messed up.
+    #
+    # However we do try to avoid crashing on None or type errors here.
+
+    raw_dependencies = yaml.get('dependencies', [])
+    if not isinstance(raw_dependencies, list):
+        raw_dependencies = []
+
+    raw_channels = yaml.get('channels', [])
+    if not isinstance(raw_channels, list):
+        raw_channels = []
+
+    conda_packages = []
+    pip_packages = []
+
+    for dep in raw_dependencies:
+        if is_string(dep):
+            conda_packages.append(dep)
+        elif isinstance(dep, dict) and 'pip' in dep and isinstance(dep['pip'], list):
+            for pip_dep in dep['pip']:
+                if is_string(pip_dep):
+                    pip_packages.append(pip_dep)
+
+    channels = []
+    for channel in raw_channels:
+        if is_string(channel):
+            channels.append(channel)
+
+    return EnvSpec(name=name, conda_packages=conda_packages, channels=channels, pip_packages=pip_packages)
+
+
+def _find_out_of_sync_environment_yml_spec(project_specs, filename):
+    spec = _load_environment_yml(filename)
+
+    if spec is None:
+        return None
+
+    for existing in project_specs:
+        if existing.name == spec.name and \
+           existing.channels_and_packages_hash == spec.channels_and_packages_hash:
+            return None
+
+    return spec

--- a/conda_kapsel/env_spec.py
+++ b/conda_kapsel/env_spec.py
@@ -132,7 +132,7 @@ def _load_environment_yml(filename):
         with codecs.open(filename, 'r', 'utf-8') as file:
             contents = file.read()
         yaml = _load_string(contents)
-    except (IOError, _YAMLError) as e:
+    except (IOError, _YAMLError):
         return None
 
     name = None

--- a/conda_kapsel/project_ops.py
+++ b/conda_kapsel/project_ops.py
@@ -97,11 +97,23 @@ def create(directory_path, make_directory=False, name=None, icon=None, descripti
     if description is not None:
         project.project_file.set_value('description', description)
 
-    # write out the kapsel.yml; note that this will try to create
-    # the directory which we may not want... so only do it if
-    # we're problem-free.
+    # dirty the project with the above new values
     project.project_file.use_changes_without_saving()
+
+    # if we're creating kapsel.yml, why not auto-fix any problems,
+    # such as environment.yaml import. Obtuse to ask since there's
+    # no existing kapsel.yml to mess up.
+    if not os.path.exists(project.project_file.filename):
+        for problem in project.fixable_problems:
+            problem.fix(project)
+
+    # dirty the project with the problem fixes
+    project.project_file.use_changes_without_saving()
+
     if len(project.problems) == 0:
+        # write out the kapsel.yml; note that this will try to create
+        # the directory which we may not want... so only do it if
+        # we're problem-free.
         project.project_file.save()
 
     return project

--- a/conda_kapsel/test/test_env_spec.py
+++ b/conda_kapsel/test/test_env_spec.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function
+
+import os
+
+from conda_kapsel.internal.test.tmpfile_utils import with_file_contents
+
+from conda_kapsel.env_spec import EnvSpec, _load_environment_yml, _find_out_of_sync_environment_yml_spec
+
+
+def test_load_environment_yml():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+        assert spec.name == 'foo'
+        assert spec.conda_packages == ('bar=1.0', 'baz')
+        assert spec.pip_packages == ('pippy', 'poppy==2.0')
+        assert spec.channels == ('channel1', 'channel2')
+
+        assert spec.channels_and_packages_hash == 'e91a2263df510c9b188b132b801ba53aa99cc407'
+
+    with_file_contents("""
+name: foo
+dependencies:
+  - bar=1.0
+  - baz
+  - pip:
+    - pippy
+    - poppy==2.0
+channels:
+  - channel1
+  - channel2
+    """, check)
+
+
+def test_load_environment_yml_with_prefix():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+        assert spec.name == 'foo'
+        assert spec.conda_packages == ('bar=1.0', 'baz')
+        assert spec.pip_packages == ('pippy', 'poppy==2.0')
+        assert spec.channels == ('channel1', 'channel2')
+
+        assert spec.channels_and_packages_hash == 'e91a2263df510c9b188b132b801ba53aa99cc407'
+
+    with_file_contents("""
+prefix: /opt/foo
+dependencies:
+  - bar=1.0
+  - baz
+  - pip:
+    - pippy
+    - poppy==2.0
+channels:
+  - channel1
+  - channel2
+    """, check)
+
+
+def test_load_environment_yml_no_name():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+        assert spec.name == os.path.basename(filename)
+        assert spec.conda_packages == ('bar=1.0', 'baz')
+        assert spec.pip_packages == ('pippy', 'poppy==2.0')
+        assert spec.channels == ('channel1', 'channel2')
+
+        assert spec.channels_and_packages_hash == 'e91a2263df510c9b188b132b801ba53aa99cc407'
+
+    with_file_contents("""
+dependencies:
+  - bar=1.0
+  - baz
+  - pip:
+    - pippy
+    - poppy==2.0
+channels:
+  - channel1
+  - channel2
+    """, check)
+
+
+def test_load_environment_yml_with_broken_sections():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+        assert spec.name == 'foo'
+        assert spec.conda_packages == ()
+        assert spec.pip_packages == ()
+        assert spec.channels == ()
+
+    with_file_contents("""
+name: foo
+dependencies: 42
+channels: 57
+    """, check)
+
+
+def test_load_environment_yml_with_broken_pip_section():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+        assert spec.name == 'foo'
+        assert spec.conda_packages == ()
+        assert spec.pip_packages == ()
+        assert spec.channels == ()
+
+    with_file_contents("""
+name: foo
+dependencies:
+ - pip: 42
+channels: 57
+    """, check)
+
+
+def test_find_in_sync_environment_yml():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+
+        desynced = _find_out_of_sync_environment_yml_spec([spec], filename)
+        assert desynced is None
+
+    with_file_contents("""
+name: foo
+dependencies:
+  - bar=1.0
+  - baz
+  - pip:
+    - pippy
+    - poppy==2.0
+channels:
+  - channel1
+  - channel2
+    """, check)
+
+
+def test_find_out_of_sync_environment_yml():
+    def check(filename):
+        spec = _load_environment_yml(filename)
+
+        assert spec is not None
+
+        changed = EnvSpec(name=spec.name,
+                          conda_packages=spec.conda_packages[1:],
+                          pip_packages=spec.pip_packages,
+                          channels=spec.channels)
+
+        desynced = _find_out_of_sync_environment_yml_spec([changed], filename)
+        assert desynced is not None
+        assert desynced.channels_and_packages_hash == spec.channels_and_packages_hash
+
+    with_file_contents("""
+name: foo
+dependencies:
+  - bar=1.0
+  - baz
+  - pip:
+    - pippy
+    - poppy==2.0
+channels:
+  - channel1
+  - channel2
+    """, check)
+
+
+def test_load_environment_yml_does_not_exist():
+    spec = _load_environment_yml("nopenopenope")
+    assert spec is None
+
+
+def test_find_out_of_sync_does_not_exist():
+    spec = _find_out_of_sync_environment_yml_spec([], "nopenopenope")
+    assert spec is None
+
+
+def test_to_json():
+    spec = EnvSpec(name="foo", conda_packages=['a', 'b'], pip_packages=['c', 'd'], channels=['x', 'y'])
+    json = spec.to_json()
+
+    assert {'channels': ['x', 'y'], 'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
+
+
+def test_diff_from():
+    spec1 = EnvSpec(name="foo", conda_packages=['a', 'b'], pip_packages=['c', 'd'], channels=['x', 'y'])
+    spec2 = EnvSpec(name="bar", conda_packages=['a', 'b', 'q'], pip_packages=['c'], channels=['x', 'y', 'z'])
+    diff = spec2.diff_from(spec1)
+
+    assert '  channels:\n      x\n      y\n    + z\n  a\n  b\n+ q\n  pip:\n      c\n    - d' == diff

--- a/conda_kapsel/yaml_file.py
+++ b/conda_kapsel/yaml_file.py
@@ -33,6 +33,9 @@ from conda_kapsel.internal.makedirs import makedirs_ok_if_exists
 from conda_kapsel.internal.rename import rename_over_existing
 from conda_kapsel.internal.py2_compat import is_string
 
+# We use this in other files (to abstract over the imports above)
+_YAMLError = YAMLError
+
 
 def _atomic_replace(path, contents, encoding='utf-8'):
     tmp = path + ".tmp-" + str(uuid.uuid4())


### PR DESCRIPTION
- if environment.yml exists on `conda-kapsel init`, just import it
  quietly
- if it changes or appears after project init, ask whether to sync
  the kapsel.yml to it
- if someone says no to the sync, save the hash in kapsel.yml
  and don't ask again
