### PR TITLE
Use a timestamp file to avoid conda/pip calls for already-OK envs

### DIFF
--- a/conda_kapsel/conda_manager.py
+++ b/conda_kapsel/conda_manager.py
@@ -77,7 +77,7 @@ class CondaManager(with_metaclass(ABCMeta)):
         pass  # pragma: no cover
 
     @abstractmethod
-    def fix_environment_deviations(self, prefix, spec, deviations=None):
+    def fix_environment_deviations(self, prefix, spec, deviations=None, create=True):
         """Fix deviations of the env in prefix from the spec.
 
         Raised exceptions that are user-interesting conda problems
@@ -89,6 +89,7 @@ class CondaManager(with_metaclass(ABCMeta)):
             prefix (str): the environment prefix (absolute path)
             spec (EnvSpec): specification for the environment
             deviations (CondaEnvironmentDeviations): optional previous result from find_environment_deviations()
+            create (bool): True if we should create if completely nonexistent
 
         Returns:
             None

--- a/conda_kapsel/internal/default_conda_manager.py
+++ b/conda_kapsel/internal/default_conda_manager.py
@@ -55,19 +55,15 @@ class DefaultCondaManager(CondaManager):
         # prefix itself
         dirs.append(prefix)
 
-        # get the newest mtime in the list
-        newest_mtime = 0
         for d in dirs:
             try:
                 d_mtime = os.path.getmtime(d)
             except OSError:
                 d_mtime = 0
-            if d_mtime > newest_mtime:
-                newest_mtime = d_mtime
-        if newest_mtime > stamp_mtime:
-            return False
-        else:
-            return True
+            if d_mtime > stamp_mtime:
+                return False
+
+        return True
 
     def _write_timestamp_file(self, prefix, spec):
         filename = self._timestamp_file(prefix, spec)

--- a/conda_kapsel/internal/default_conda_manager.py
+++ b/conda_kapsel/internal/default_conda_manager.py
@@ -40,7 +40,12 @@ class DefaultCondaManager(CondaManager):
         # to become more comprehensive.  We don't want to check
         # directories that would change at runtime like /var/run,
         # and we need this to be reasonably fast (so we can't do a
-        # full directory walk or something).
+        # full directory walk or something). Remember that on
+        # Linux at least a new mtime on a directory means
+        # _immediate_ child directory entries were added or
+        # removed, changing the files themselves or the files in
+        # subdirs will not affect mtime. Windows may be a bit
+        # different.
 
         # Linux
         dirs = list(glob.iglob(os.path.join(prefix, "lib", "python*", "site-packages")))
@@ -52,8 +57,6 @@ class DefaultCondaManager(CondaManager):
         dirs.append(os.path.join(prefix, "Scripts"))
         # conda-meta
         dirs.append(os.path.join(prefix, "conda-meta"))
-        # prefix itself
-        dirs.append(prefix)
 
         for d in dirs:
             try:

--- a/conda_kapsel/internal/test/test_default_conda_manager.py
+++ b/conda_kapsel/internal/test/test_default_conda_manager.py
@@ -128,6 +128,7 @@ def test_timestamp_file_avoids_package_manager_calls(monkeypatch):
 
         assert deviations.missing_packages == ('ipython', )
         assert deviations.missing_pip_packages == ('flake8', )
+        assert not deviations.ok
 
         manager.fix_environment_deviations(envdir, spec, deviations)
 
@@ -160,6 +161,7 @@ def test_timestamp_file_avoids_package_manager_calls(monkeypatch):
 
         assert deviations.missing_packages == ()
         assert deviations.missing_pip_packages == ()
+        assert deviations.ok
 
         assert manager._timestamp_file_up_to_date(envdir, spec)
 
@@ -177,6 +179,8 @@ def test_timestamp_file_avoids_package_manager_calls(monkeypatch):
 
         assert deviations.missing_packages == ()
         assert deviations.missing_pip_packages == ()
+        # deviations should not be ok (due to timestamp)
+        assert not deviations.ok
 
         assert not manager._timestamp_file_up_to_date(envdir, spec)
 

--- a/conda_kapsel/test/test_prepare.py
+++ b/conda_kapsel/test/test_prepare.py
@@ -283,7 +283,7 @@ def _push_fake_env_creator():
                                               missing_pip_packages=(),
                                               wrong_version_pip_packages=())
 
-        def fix_environment_deviations(self, prefix, spec, deviations=None):
+        def fix_environment_deviations(self, prefix, spec, deviations=None, create=True):
             pass
 
         def remove_packages(self, prefix, packages):

--- a/conda_kapsel/test/test_project_ops.py
+++ b/conda_kapsel/test/test_project_ops.py
@@ -1221,7 +1221,7 @@ def _push_conda_test(fix_works, missing_packages, wrong_version_packages, remove
             else:
                 return self.deviations
 
-        def fix_environment_deviations(self, prefix, spec, deviations=None):
+        def fix_environment_deviations(self, prefix, spec, deviations=None, create=True):
             if self.fix_works:
                 self.fixed = True
 


### PR DESCRIPTION
 * when we update an env successfully, write a file with the
   env spec hash in the name
 * if this file exists and is newer than the bin/lib dirs
   in the prefix, we don't do anything to update the env