### PR TITLE
add --verbose command line flag to log more information

### DIFF
--- a/conda_kapsel/archiver.py
+++ b/conda_kapsel/archiver.py
@@ -19,6 +19,7 @@ import tempfile
 import uuid
 import zipfile
 
+from conda_kapsel.internal import logged_subprocess
 from conda_kapsel.internal.simple_status import SimpleStatus
 from conda_kapsel.internal.directory_contains import subdirectory_relative_to_directory
 from conda_kapsel.internal.rename import rename_over_existing
@@ -159,7 +160,7 @@ def _git_ignored_files(project_directory, errors):
     # --exclude-standard means use the usual .gitignore and other configuration
     # --directory means output "node_modules/" if it's ignored, not 100000 JS files
     try:
-        output = subprocess.check_output(
+        output = logged_subprocess.check_output(
             ['git', 'ls-files', '--others', '--ignored', '--exclude-standard', '--directory'],
             cwd=project_directory)
         # for whatever reason, git doesn't include the ".git" in the ignore list

--- a/conda_kapsel/commands/main.py
+++ b/conda_kapsel/commands/main.py
@@ -7,6 +7,7 @@
 """The ``main`` function chooses and runs a subcommand."""
 from __future__ import absolute_import, print_function
 
+import logging
 import os
 import sys
 from argparse import ArgumentParser, REMAINDER
@@ -14,6 +15,7 @@ from argparse import ArgumentParser, REMAINDER
 from conda_kapsel.commands.prepare_with_mode import (UI_MODE_TEXT_ASK_QUESTIONS,
                                                      UI_MODE_TEXT_DEVELOPMENT_DEFAULTS_OR_ASK, _all_ui_modes)
 from conda_kapsel.version import version
+from conda_kapsel.verbose import push_verbose_logger, pop_verbose_logger
 from conda_kapsel.project import ALL_COMMAND_TYPES
 from conda_kapsel.plugins.registry import PluginRegistry
 from conda_kapsel.plugins.requirements.download import _hash_algorithms
@@ -37,12 +39,10 @@ import conda_kapsel.commands.command_commands as command_commands
 def _parse_args_and_run_subcommand(argv):
     parser = ArgumentParser(prog="conda-kapsel", description="Actions on kapsels (runnable projects).")
 
-    # future: make setup.py store our version in a version.py then use that here
-    # parser.add_argument('-v', '--version', action='version', version='0.1')
-
     subparsers = parser.add_subparsers(help="Sub-commands")
 
     parser.add_argument('-v', '--version', action='version', version=version)
+    parser.add_argument('--verbose', action='store_true', default=False, help="show verbose debugging details")
 
     def add_directory_arg(preset):
         preset.add_argument('--directory',
@@ -277,11 +277,22 @@ def _parse_args_and_run_subcommand(argv):
     except SystemExit as e:
         return e.code
 
-    # '--directory' is used for most subcommands; for unarchive,
-    # args.directory is positional and may be None
-    if 'directory' in args and args.directory is not None:
-        args.directory = os.path.abspath(args.directory)
-    return args.main(args)
+    if args.verbose:
+        logger = logging.getLogger(name="conda_kapsel_verbose")
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler(stream=sys.stderr)
+        logger.addHandler(handler)
+        push_verbose_logger(logger)
+
+    try:
+        # '--directory' is used for most subcommands; for unarchive,
+        # args.directory is positional and may be None
+        if 'directory' in args and args.directory is not None:
+            args.directory = os.path.abspath(args.directory)
+        return args.main(args)
+    finally:
+        if args.verbose:
+            pop_verbose_logger()
 
 
 def _main_without_bug_handler():

--- a/conda_kapsel/commands/main.py
+++ b/conda_kapsel/commands/main.py
@@ -278,7 +278,7 @@ def _parse_args_and_run_subcommand(argv):
         return e.code
 
     if args.verbose:
-        logger = logging.getLogger(name="conda_kapsel_verbose")
+        logger = (logging.getLoggerClass())(name="conda_kapsel_verbose")
         logger.setLevel(logging.DEBUG)
         handler = logging.StreamHandler(stream=sys.stderr)
         logger.addHandler(handler)

--- a/conda_kapsel/commands/test/test_main.py
+++ b/conda_kapsel/commands/test/test_main.py
@@ -29,7 +29,7 @@ def test_main_no_subcommand(capsys):
     out, err = capsys.readouterr()
     assert "" == out
     expected_error_msg = ('Must specify a subcommand.\n'
-                          'usage: conda-kapsel [-h] [-v]\n'
+                          'usage: conda-kapsel [-h] [-v] [--verbose]\n'
                           '                    %s\n'
                           '                    ...\n') % all_subcommands_in_curlies
     assert expected_error_msg == err
@@ -39,7 +39,7 @@ def test_main_bad_subcommand(capsys):
     code = _parse_args_and_run_subcommand(['project', 'foo'])
 
     out, err = capsys.readouterr()
-    expected_error_msg = ("usage: conda-kapsel [-h] [-v]\n"
+    expected_error_msg = ("usage: conda-kapsel [-h] [-v] [--verbose]\n"
                           "                    %s\n"
                           "                    ...\nconda-kapsel: error: invalid choice: 'foo' "
                           "(choose from %s)\n") % (all_subcommands_in_curlies, all_subcommands_comma_space)
@@ -50,7 +50,7 @@ def test_main_bad_subcommand(capsys):
 
 
 expected_usage_msg_format = \
-        'usage: conda-kapsel [-h] [-v]\n' \
+        'usage: conda-kapsel [-h] [-v] [--verbose]\n' \
         '                    %s\n' \
         '                    ...\n' \
         '\n' \
@@ -97,7 +97,8 @@ expected_usage_msg_format = \
         '\n' \
         'optional arguments:\n' \
         '  -h, --help            show this help message and exit\n' \
-        "  -v, --version         show program's version number and exit\n"
+        "  -v, --version         show program's version number and exit\n" \
+        '  --verbose             show verbose debugging details\n'
 
 activate_help = '    activate            Set up the project and output shell export commands\n' \
                 '                        reflecting the setup\n'

--- a/conda_kapsel/internal/conda_api.py
+++ b/conda_kapsel/internal/conda_api.py
@@ -15,6 +15,7 @@ import platform
 import re
 import sys
 
+from conda_kapsel.internal import logged_subprocess
 from conda_kapsel.internal.directory_contains import subdirectory_relative_to_directory
 
 
@@ -42,7 +43,7 @@ def _call_conda(extra_args):
     cmd_list = _get_conda_command(extra_args)
 
     try:
-        p = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = logged_subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError as e:
         raise CondaError("failed to run: %r: %r" % (" ".join(cmd_list), repr(e)))
     (out, err) = p.communicate()

--- a/conda_kapsel/internal/logged_subprocess.py
+++ b/conda_kapsel/internal/logged_subprocess.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function
+
+import subprocess
+
+from conda_kapsel import verbose
+
+
+def _log_args(args):
+    log = verbose._verbose_logger()
+    log.info("$ %s", " ".join(args))
+
+
+def call(args, **kwargs):
+    _log_args(args)
+    return subprocess.call(args=args, **kwargs)
+
+
+def Popen(args, **kwargs):
+    _log_args(args)
+    return subprocess.Popen(args=args, **kwargs)
+
+
+def check_output(args, **kwargs):
+    _log_args(args)
+    return subprocess.check_output(args=args, **kwargs)

--- a/conda_kapsel/internal/pip_api.py
+++ b/conda_kapsel/internal/pip_api.py
@@ -12,6 +12,8 @@ import os
 import re
 import sys
 
+from conda_kapsel.internal import logged_subprocess
+
 
 class PipError(Exception):
     """General pip error."""
@@ -42,7 +44,7 @@ def _call_pip(prefix, extra_args):
     cmd_list = _get_pip_command(prefix, extra_args)
 
     try:
-        p = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = logged_subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except OSError as e:
         raise PipError("failed to run: %r: %r" % (" ".join(cmd_list), repr(e)))
     (out, err) = p.communicate()

--- a/conda_kapsel/internal/test/test_logged_subprocess.py
+++ b/conda_kapsel/internal/test/test_logged_subprocess.py
@@ -22,7 +22,7 @@ class ArrayHandler(logging.Handler):
 
 
 def _test_logger():
-    logger = logging.getLogger(name="test_logged_subprocess")
+    logger = (logging.getLoggerClass())(name="test_logged_subprocess")
     logger.setLevel(logging.DEBUG)
     handler = ArrayHandler()
     logger.addHandler(handler)

--- a/conda_kapsel/internal/test/test_logged_subprocess.py
+++ b/conda_kapsel/internal/test/test_logged_subprocess.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function
+
+import logging
+
+from conda_kapsel import verbose
+from conda_kapsel.internal import logged_subprocess
+
+
+class ArrayHandler(logging.Handler):
+    def __init__(self):
+        super(ArrayHandler, self).__init__(level=logging.DEBUG)
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.msg % record.args)
+
+
+def _test_logger():
+    logger = logging.getLogger(name="test_logged_subprocess")
+    logger.setLevel(logging.DEBUG)
+    handler = ArrayHandler()
+    logger.addHandler(handler)
+    logger.messages = handler.messages
+    return logger
+
+
+def test_log_subprocess_call(monkeypatch):
+    recorded = dict(args=(), kwargs=())
+
+    def mock_call(*args, **kwargs):
+        recorded['args'] = args
+        recorded['kwargs'] = kwargs
+
+    monkeypatch.setattr('subprocess.call', mock_call)
+
+    logged_subprocess.call(['a', 'b'], foo='bar')
+
+    assert recorded == dict(args=(), kwargs=dict(args=['a', 'b'], foo='bar'))
+
+
+def test_log_subprocess_call_with_logging(monkeypatch):
+    logger = _test_logger()
+    verbose.push_verbose_logger(logger)
+    try:
+
+        recorded = dict(args=(), kwargs=())
+
+        def mock_call(*args, **kwargs):
+            recorded['args'] = args
+            recorded['kwargs'] = kwargs
+
+        monkeypatch.setattr('subprocess.call', mock_call)
+
+        logged_subprocess.call(['a', 'b'], foo='bar')
+
+        assert recorded == dict(args=(), kwargs=dict(args=['a', 'b'], foo='bar'))
+
+        assert logger.messages == ['$ a b']
+    finally:
+        verbose.pop_verbose_logger()
+
+
+def test_log_subprocess_Popen(monkeypatch):
+    recorded = dict(args=(), kwargs=())
+
+    def mock_Popen(*args, **kwargs):
+        recorded['args'] = args
+        recorded['kwargs'] = kwargs
+
+    monkeypatch.setattr('subprocess.Popen', mock_Popen)
+
+    logged_subprocess.Popen(['a', 'b'], foo='bar')
+
+    assert recorded == dict(args=(), kwargs=dict(args=['a', 'b'], foo='bar'))
+
+
+def test_log_subprocess_Popen_with_logging(monkeypatch):
+    logger = _test_logger()
+    verbose.push_verbose_logger(logger)
+    try:
+
+        recorded = dict(args=(), kwargs=())
+
+        def mock_Popen(*args, **kwargs):
+            recorded['args'] = args
+            recorded['kwargs'] = kwargs
+
+        monkeypatch.setattr('subprocess.Popen', mock_Popen)
+
+        logged_subprocess.Popen(['a', 'b'], foo='bar')
+
+        assert recorded == dict(args=(), kwargs=dict(args=['a', 'b'], foo='bar'))
+
+        assert logger.messages == ['$ a b']
+    finally:
+        verbose.pop_verbose_logger()
+
+
+def test_log_subprocess_check_output(monkeypatch):
+    recorded = dict(args=(), kwargs=())
+
+    def mock_check_output(*args, **kwargs):
+        recorded['args'] = args
+        recorded['kwargs'] = kwargs
+
+    monkeypatch.setattr('subprocess.check_output', mock_check_output)
+
+    logged_subprocess.check_output(['a', 'b'], foo='bar')
+
+    assert recorded == dict(args=(), kwargs=dict(args=['a', 'b'], foo='bar'))
+
+
+def test_log_subprocess_check_output_with_logging(monkeypatch):
+    logger = _test_logger()
+    verbose.push_verbose_logger(logger)
+    try:
+
+        recorded = dict(args=(), kwargs=())
+
+        def mock_check_output(*args, **kwargs):
+            recorded['args'] = args
+            recorded['kwargs'] = kwargs
+
+        monkeypatch.setattr('subprocess.check_output', mock_check_output)
+
+        logged_subprocess.check_output(['a', 'b'], foo='bar')
+
+        assert recorded == dict(args=(), kwargs=dict(args=['a', 'b'], foo='bar'))
+
+        assert logger.messages == ['$ a b']
+    finally:
+        verbose.pop_verbose_logger()

--- a/conda_kapsel/plugins/provider.py
+++ b/conda_kapsel/plugins/provider.py
@@ -11,9 +11,9 @@ from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 import os
 import shutil
-import subprocess
 
 from conda_kapsel.internal import conda_api
+from conda_kapsel.internal import logged_subprocess
 from conda_kapsel.internal.metaclass import with_metaclass
 from conda_kapsel.internal.makedirs import makedirs_ok_if_exists
 from conda_kapsel.internal.simple_status import SimpleStatus
@@ -124,7 +124,7 @@ def shutdown_service_run_state(local_state_file, service_name):
     if 'shutdown_commands' in state:
         commands = state['shutdown_commands']
         for command in commands:
-            code = subprocess.call(command)
+            code = logged_subprocess.call(command)
             if code != 0:
                 errors.append("Shutting down %s, command %s failed with code %d." % (service_name, repr(command), code))
     # clear out the run state once we try to shut it down

--- a/conda_kapsel/plugins/providers/redis.py
+++ b/conda_kapsel/plugins/providers/redis.py
@@ -19,6 +19,7 @@ from conda_kapsel.plugins.provider import (EnvVarProvider, ProviderAnalysis, shu
 import conda_kapsel.plugins.network_util as network_util
 from conda_kapsel.provide import PROVIDE_MODE_DEVELOPMENT
 from conda_kapsel.internal import py2_compat
+from conda_kapsel.internal import logged_subprocess
 
 _DEFAULT_SYSTEM_REDIS_HOST = "localhost"
 _DEFAULT_SYSTEM_REDIS_PORT = 6379
@@ -245,9 +246,9 @@ class RedisProvider(EnvVarProvider):
             # keep us from collected stderr. But on Unix it's kinda broken not
             # to close_fds. Hmm.
             try:
-                popen = subprocess.Popen(args=command,
-                                         stderr=subprocess.PIPE,
-                                         env=py2_compat.env_without_unicode(context.environ))
+                popen = logged_subprocess.Popen(args=command,
+                                                stderr=subprocess.PIPE,
+                                                env=py2_compat.env_without_unicode(context.environ))
             except Exception as e:
                 errors.append("Error executing redis-server: %s" % (str(e)))
                 return None

--- a/conda_kapsel/verbose.py
+++ b/conda_kapsel/verbose.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+"""Control verbose output."""
+from __future__ import absolute_import
+
+import logging
+
+_verbose_loggers = []
+
+
+def push_verbose_logger(logger):
+    """Push a logger to log verbose messgaes."""
+    global _verbose_loggers
+    _verbose_loggers.append(logger)
+
+
+def pop_verbose_logger():
+    """Remove the most recently-pushed verbose logger."""
+    global _verbose_loggers
+    assert len(_verbose_loggers) > 0
+    _verbose_loggers.pop()
+
+
+_cached_null_logger = None
+
+
+def _null_logger():
+    global _cached_null_logger
+    if _cached_null_logger is None:
+        logger = logging.getLogger(name='conda_kapsel_null')
+        logger.addHandler(logging.NullHandler())
+        _cached_null_logger = logger
+    return _cached_null_logger
+
+
+def _verbose_logger():
+    """Used internal to conda-kapsel library to get the current verbose logger."""
+    if len(_verbose_loggers) > 0:
+        return _verbose_loggers[-1]
+    else:
+        return _null_logger()


### PR DESCRIPTION
For the moment, all this does is log any subprocesses
we create so you can sort of watch conda-kapsel as if it
were a shell script.

Can get fancier later.