### PR TITLE
When running a notebook, set the default_url to that notebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       OS_PACKAGES=libffi ;
     fi ;
-    conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip redis pycrypto bcrypt ipython-notebook bokeh ruamel_yaml anaconda-client requests $OS_PACKAGES
+    conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip redis pycrypto bcrypt ipython-notebook bokeh ruamel_yaml anaconda-client requests psutil $OS_PACKAGES
   - source activate test-environment
   - printenv | sort
   - unset CONDA_ENV_PATH # because the older conda in miniconda sets this, confusing some tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
       MINICONDA_OS=MacOSX ;
     fi ;
     echo "Fetching Python $MINICONDA_VERSION miniconda for $MINICONDA_OS" ;
-    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_VERSION-4.2.12-$MINICONDA_OS-x86_64.sh -O miniconda.sh
+    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_VERSION-4.1.11-$MINICONDA_OS-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p "$HOME"/miniconda
   - source "$HOME"/miniconda/bin/activate root
   - printenv | sort

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ install:
       MINICONDA_OS=MacOSX ;
     fi ;
     echo "Fetching Python $MINICONDA_VERSION miniconda for $MINICONDA_OS" ;
-    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_VERSION-latest-$MINICONDA_OS-x86_64.sh -O miniconda.sh
+    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_VERSION-4.2.12-$MINICONDA_OS-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p "$HOME"/miniconda
   - source "$HOME"/miniconda/bin/activate root
   - printenv | sort
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
   - conda update -n root conda
   - conda install -n root conda-build
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ install:
   - source "$HOME"/miniconda/bin/activate root
   - printenv | sort
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
-  - conda update -n root conda
-  - conda install -n root conda-build
+  - conda install -n root conda-build psutil
   - conda info -a
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       OS_PACKAGES=libffi ;

--- a/conda_kapsel/commands/test/test_run.py
+++ b/conda_kapsel/commands/test/test_run.py
@@ -490,8 +490,9 @@ def test_run_notebook_not_in_config(monkeypatch, capsys):
     args = _test_run_command_foo(
         ['conda-kapsel', 'run', '--directory', '<DIRNAME>',
          'something.ipynb'], monkeypatch, capsys, _func_asserting_contains('jupyter-notebook'))
-    assert len(args) == 1
+    assert len(args) == 2
     assert args[0].endswith('something.ipynb')
+    assert args[1] == '--NotebookApp.default_url=/notebooks/something.ipynb'
 
 
 def test_run_command_nonexistent_name(monkeypatch, capsys):

--- a/conda_kapsel/plugins/providers/test/test_conda_env.py
+++ b/conda_kapsel/plugins/providers/test/test_conda_env.py
@@ -195,6 +195,7 @@ def test_prepare_project_scoped_env_with_packages(monkeypatch):
         project.project_file.save()
         environ = minimal_environ(PROJECT_DIR=dirname)
         result = prepare_without_interaction(project, environ=environ)
+        result.print_output()
         assert result
 
         prefix = result.environ[conda_env_var]

--- a/conda_kapsel/plugins/providers/test/test_conda_env.py
+++ b/conda_kapsel/plugins/providers/test/test_conda_env.py
@@ -187,11 +187,11 @@ def test_prepare_project_scoped_env_with_packages(monkeypatch):
 
         assert 'ipython' in installed
         assert 'numpy' in installed
-        assert 'ipython-notebook' not in installed
+        assert 'bokeh' not in installed
 
         # Preparing it again with new packages added should add those
         deps = project.project_file.get_value('packages')
-        project.project_file.set_value('packages', deps + ['ipython-notebook'])
+        project.project_file.set_value('packages', deps + ['bokeh'])
         project.project_file.save()
         environ = minimal_environ(PROJECT_DIR=dirname)
         result = prepare_without_interaction(project, environ=environ)
@@ -203,7 +203,7 @@ def test_prepare_project_scoped_env_with_packages(monkeypatch):
 
         assert 'ipython' in installed
         assert 'numpy' in installed
-        assert 'ipython-notebook' in installed
+        assert 'bokeh' in installed
 
         installed_pip = pip_api.installed(prefix)
         assert 'flake8' in installed_pip

--- a/conda_kapsel/test/test_project.py
+++ b/conda_kapsel/test/test_project.py
@@ -1125,7 +1125,8 @@ def test_notebook_command():
         cmd_exec = command.exec_info_for_environment(environ)
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = find_executable('jupyter-notebook', path)
-        assert cmd_exec.args == [jupyter_notebook, os.path.join(dirname, 'test.ipynb')]
+        assert cmd_exec.args == [jupyter_notebook, os.path.join(dirname, 'test.ipynb'),
+                                 '--NotebookApp.default_url=/notebooks/test.ipynb']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file(
@@ -1146,7 +1147,8 @@ def test_notebook_command_extra_args():
         cmd_exec = command.exec_info_for_environment(environ, extra_args=['foo', 'bar'])
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = find_executable('jupyter-notebook', path)
-        assert cmd_exec.args == [jupyter_notebook, os.path.join(dirname, 'test.ipynb'), 'foo', 'bar']
+        assert cmd_exec.args == [jupyter_notebook, os.path.join(dirname, 'test.ipynb'),
+                                 '--NotebookApp.default_url=/notebooks/test.ipynb', 'foo', 'bar']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file(
@@ -1174,7 +1176,8 @@ def test_notebook_command_with_kapsel_http_args():
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = find_executable('jupyter-notebook', path)
         assert cmd_exec.args == [
-            jupyter_notebook, os.path.join(dirname, 'test.ipynb'), '--NotebookApp.tornado_settings=' +
+            jupyter_notebook, os.path.join(dirname, 'test.ipynb'), '--NotebookApp.default_url=/notebooks/test.ipynb',
+            '--NotebookApp.tornado_settings=' +
             """{ 'headers': { 'Content-Security-Policy': "frame-ancestors 'self' foo1.com *.foo2.com" } }""",
             '--no-browser', '--port', '1234', '--NotebookApp.base_url=blah', '--NotebookApp.trust_xheaders=True', 'foo',
             'bar'
@@ -1232,8 +1235,9 @@ def test_notebook_command_kapsel_http_args_after_double_hyphen():
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = find_executable('jupyter-notebook', path)
         assert cmd_exec.args == [jupyter_notebook, os.path.join(
-            dirname, 'test.ipynb'), '--', 'foo', 'bar', '--kapsel-url-prefix', 'blah', '--kapsel-port', '1234',
-                                 '--kapsel-host', 'example.com', '--kapsel-no-browser', '--kapsel-use-xheaders']
+            dirname, 'test.ipynb'), '--NotebookApp.default_url=/notebooks/test.ipynb', '--', 'foo', 'bar',
+                                 '--kapsel-url-prefix', 'blah', '--kapsel-port', '1234', '--kapsel-host', 'example.com',
+                                 '--kapsel-no-browser', '--kapsel-use-xheaders']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file(
@@ -1257,8 +1261,9 @@ def test_notebook_command_with_kapsel_http_args_separated_by_equals():
                         '--kapsel-no-browser'])
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = find_executable('jupyter-notebook', path)
-        assert cmd_exec.args == [jupyter_notebook, os.path.join(dirname, 'test.ipynb'), '--no-browser', '--port',
-                                 '1234', '--NotebookApp.base_url=blah', 'foo', 'bar']
+        assert cmd_exec.args == [jupyter_notebook, os.path.join(
+            dirname, 'test.ipynb'), '--NotebookApp.default_url=/notebooks/test.ipynb', '--no-browser', '--port', '1234',
+                                 '--NotebookApp.base_url=blah', 'foo', 'bar']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file(
@@ -1285,7 +1290,7 @@ def test_notebook_guess_command():
         cmd_exec = command.exec_info_for_environment(environ)
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = find_executable('jupyter-notebook', path)
-        assert cmd_exec.args == [jupyter_notebook, expected_nb_path]
+        assert cmd_exec.args == [jupyter_notebook, expected_nb_path, '--NotebookApp.default_url=/notebooks/test.ipynb']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file(
@@ -1463,7 +1468,8 @@ def test_bokeh_command_with_multiple_iframe_hosts_args():
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter = find_executable('jupyter-notebook', path)
         assert cmd_exec.args == [
-            jupyter, os.path.join(dirname, 'test.ipynb'), '--NotebookApp.tornado_settings=' +
+            jupyter, os.path.join(dirname, 'test.ipynb'), '--NotebookApp.default_url=/notebooks/test.ipynb',
+            '--NotebookApp.tornado_settings=' +
             """{ 'headers': { 'Content-Security-Policy': "frame-ancestors 'self' example.com foo1.com *.foo2.com" } }"""
         ]
         assert cmd_exec.shell is False

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,10 @@ class AllTestsCommand(TestCommand):
             # 2, maybe due to an interaction with coverage
             enable_xdist = []
         else:
-            enable_xdist = ['-n', str(CPU_COUNT)]
+            # Recent conda downright explodes if run from multiple processes at once,
+            # so skip xdist until we add our own locking layer or something.
+            enable_xdist = []
+            # enable_xdist = ['-n', str(CPU_COUNT)]
         self.pytest_args = ['-rfew', '--durations=10'] + enable_xdist
         # 100% coverage on Windows requires us to do extra mocks because generally Windows
         # can't run all the servers, such as redis-server. So we relax the coverage requirement


### PR DESCRIPTION
This changes browsing to / into /notebooks/foo.ipynb instead of /tree.

In the default case where we open a browser, this makes little difference
because Jupyter opens to /notebooks/foo.ipynb instead of / anyhow.
It does break where clicking the Jupyter logo takes you; wish that
was hardcoded to /tree in Jupyter.

The purpose of this change is when we're deploying a notebook as an http
app, / does the right thing. Potentially we should only set default_url
when --kapsel-no-browser is provided? But that seems sort of magic, so
not doing that for now.