### PR TITLE
add a --command option to conda-kapsel prepare

### DIFF
--- a/conda_kapsel/commands/activate.py
+++ b/conda_kapsel/commands/activate.py
@@ -18,7 +18,7 @@ from conda_kapsel.commands.prepare_with_mode import prepare_with_ui_mode_printin
 from conda_kapsel.commands.project_load import load_project
 
 
-def activate(dirname, ui_mode, conda_environment):
+def activate(dirname, ui_mode, conda_environment, command_name):
     """Prepare project and return lines to be sourced.
 
     Future direction: should also activate the proper conda env.
@@ -27,7 +27,10 @@ def activate(dirname, ui_mode, conda_environment):
         None on failure or a list of lines to print.
     """
     project = load_project(dirname)
-    result = prepare_with_ui_mode_printing_errors(project, ui_mode=ui_mode, env_spec_name=conda_environment)
+    result = prepare_with_ui_mode_printing_errors(project,
+                                                  ui_mode=ui_mode,
+                                                  env_spec_name=conda_environment,
+                                                  command_name=command_name)
     if result.failed:
         return None
 
@@ -44,7 +47,7 @@ def activate(dirname, ui_mode, conda_environment):
 
 def main(args):
     """Start the activate command and return exit status code."""
-    result = activate(args.directory, args.mode, args.env_spec)
+    result = activate(args.directory, args.mode, args.env_spec, args.command)
     if result is None:
         return 1
     else:

--- a/conda_kapsel/commands/main.py
+++ b/conda_kapsel/commands/main.py
@@ -57,7 +57,7 @@ def _parse_args_and_run_subcommand(argv):
                             action='store',
                             help="An environment spec name from kapsel.yml")
 
-    def add_prepare_args(preset):
+    def add_prepare_args(preset, include_command=True):
         add_directory_arg(preset)
         add_env_spec_arg(preset)
         all_supported_modes = list(_all_ui_modes)
@@ -69,6 +69,12 @@ def _parse_args_and_run_subcommand(argv):
                             choices=_all_ui_modes,
                             action='store',
                             help="One of " + ", ".join(_all_ui_modes))
+        if include_command:
+            preset.add_argument('--command',
+                                metavar='COMMAND_NAME',
+                                default=None,
+                                action='store',
+                                help="A command name from kapsel.yml (env spec for this command will be used)")
 
     def add_env_spec_name_arg(preset):
         preset.add_argument('-n',
@@ -82,7 +88,7 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=init.main)
 
     preset = subparsers.add_parser('run', help="Run the project, setting up requirements first")
-    add_prepare_args(preset)
+    add_prepare_args(preset, include_command=False)
     preset.add_argument('command',
                         metavar='COMMAND_NAME',
                         default=None,

--- a/conda_kapsel/commands/prepare.py
+++ b/conda_kapsel/commands/prepare.py
@@ -11,21 +11,24 @@ from conda_kapsel.commands.prepare_with_mode import prepare_with_ui_mode_printin
 from conda_kapsel.commands.project_load import load_project
 
 
-def prepare_command(project_dir, ui_mode, conda_environment):
+def prepare_command(project_dir, ui_mode, conda_environment, command_name):
     """Configure the project to run.
 
     Returns:
         Prepare result (can be treated as True on success).
     """
     project = load_project(project_dir)
-    result = prepare_with_ui_mode_printing_errors(project, env_spec_name=conda_environment, ui_mode=ui_mode)
+    result = prepare_with_ui_mode_printing_errors(project,
+                                                  env_spec_name=conda_environment,
+                                                  ui_mode=ui_mode,
+                                                  command_name=command_name)
 
     return result
 
 
 def main(args):
     """Start the prepare command and return exit status code."""
-    if prepare_command(args.directory, args.mode, args.env_spec):
+    if prepare_command(args.directory, args.mode, args.env_spec, args.command):
         print("The project is ready to run commands.")
         print("Use `conda-kapsel list-commands` to see what's available.")
         return 0


### PR DESCRIPTION
This is an indirect way to select the env spec to be prepared,
based on the command that you intend to run.