### PR TITLE
add --yes parameter to init subcommand

### DIFF
--- a/conda_kapsel/commands/init.py
+++ b/conda_kapsel/commands/init.py
@@ -13,18 +13,26 @@ from conda_kapsel import project_ops
 from conda_kapsel.commands.console_utils import (print_project_problems, console_ask_yes_or_no)
 
 
-def init_command(project_dir):
+def init_command(project_dir, assume_yes):
     """Initialize a new project.
 
     Returns:
         Exit code (0 on success)
     """
+    # we don't want False right now because either you specify
+    # --yes or we go with the default in project_ops.create
+    # (depends on whether project file already exists).
+    assert assume_yes is None or assume_yes is True
+
     if not os.path.exists(project_dir):
-        make_directory = console_ask_yes_or_no("Create directory '%s'?" % project_dir, False)
+        if assume_yes:
+            make_directory = True
+        else:
+            make_directory = console_ask_yes_or_no("Create directory '%s'?" % project_dir, default=False)
     else:
         make_directory = False
 
-    project = project_ops.create(project_dir, make_directory=make_directory)
+    project = project_ops.create(project_dir, make_directory=make_directory, fix_problems=assume_yes)
     if print_project_problems(project):
         return 1
     else:
@@ -34,4 +42,4 @@ def init_command(project_dir):
 
 def main(args):
     """Start the init command and return exit status code."""
-    return init_command(args.directory)
+    return init_command(args.directory, args.yes)

--- a/conda_kapsel/commands/main.py
+++ b/conda_kapsel/commands/main.py
@@ -85,6 +85,7 @@ def _parse_args_and_run_subcommand(argv):
 
     preset = subparsers.add_parser('init', help="Initialize a directory with default project configuration")
     add_directory_arg(preset)
+    preset.add_argument('-y', '--yes', action='store_true', help="Assume yes to all confirmation prompts", default=None)
     preset.set_defaults(main=init.main)
 
     preset = subparsers.add_parser('run', help="Run the project, setting up requirements first")

--- a/conda_kapsel/commands/test/test_init.py
+++ b/conda_kapsel/commands/test/test_init.py
@@ -123,3 +123,27 @@ def test_init_do_not_create_directory_not_interactive(capsys, monkeypatch):
         assert ("Project directory '%s' does not exist.\nUnable to load the project.\n" % subdir) == err
 
     with_directory_contents(dict(), check)
+
+
+def test_init_create_directory_not_interactive_with_yes(capsys, monkeypatch):
+    _monkeypatch_isatty(monkeypatch, False)
+
+    def mock_input(prompt):
+        raise RuntimeError("This should not have been called")
+
+    monkeypatch.setattr('conda_kapsel.commands.console_utils._input', mock_input)
+
+    def check(dirname):
+        subdir = os.path.join(dirname, "foo")
+
+        code = _parse_args_and_run_subcommand(['conda-kapsel', 'init', '--yes', '--directory', subdir])
+        assert code == 0
+
+        assert os.path.isfile(os.path.join(subdir, DEFAULT_PROJECT_FILENAME))
+        assert os.path.isdir(subdir)
+
+        out, err = capsys.readouterr()
+        assert ("Project configuration is in %s\n" % (os.path.join(subdir, DEFAULT_PROJECT_FILENAME))) == out
+        assert '' == err
+
+    with_directory_contents(dict(), check)

--- a/conda_kapsel/project_ops.py
+++ b/conda_kapsel/project_ops.py
@@ -56,7 +56,7 @@ def _add_projectignore_if_none(project_directory):
             pass
 
 
-def create(directory_path, make_directory=False, name=None, icon=None, description=None):
+def create(directory_path, make_directory=False, name=None, icon=None, description=None, fix_problems=None):
     """Create a project skeleton in the given directory.
 
     Returns a Project instance even if creation fails or the directory
@@ -74,6 +74,7 @@ def create(directory_path, make_directory=False, name=None, icon=None, descripti
         name (str): Name of the new project or None to leave unset (uses directory name)
         icon (str): Icon for the new project or None to leave unset (uses no icon)
         description (str): Description for the new project or None to leave unset
+        fix_problems (bool): True to always fix problems even if project file existed
 
     Returns:
         a Project instance
@@ -103,7 +104,9 @@ def create(directory_path, make_directory=False, name=None, icon=None, descripti
     # if we're creating kapsel.yml, why not auto-fix any problems,
     # such as environment.yaml import. Obtuse to ask since there's
     # no existing kapsel.yml to mess up.
-    if not os.path.exists(project.project_file.filename):
+    if fix_problems is None:
+        fix_problems = not os.path.exists(project.project_file.filename)
+    if fix_problems:
         for problem in project.fixable_problems:
             problem.fix(project)
 

--- a/conda_kapsel/test/test_project_ops.py
+++ b/conda_kapsel/test/test_project_ops.py
@@ -98,11 +98,74 @@ def test_create_imports_environment_yml():
         assert [] == project.problems
         assert os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
 
+        # TODO we shouldn't BOTH create 'default' and import 'stuff' probably
         assert sorted(list(project.env_specs.keys())) == sorted(['stuff', 'default'])
         spec = project.env_specs['stuff']
         assert spec.conda_packages == ('a', 'b')
         assert spec.pip_packages == ('foo', )
         assert spec.channels == ('bar', )
+
+    with_directory_contents(
+        {'something.png': 'not a real png',
+         "environment.yml": """
+name: stuff
+dependencies:
+ - a
+ - b
+ - pip:
+   - foo
+channels:
+ - bar
+"""}, check_create)
+
+
+def test_create_imports_environment_yml_when_kapsel_yml_exists_and_fix_problems():
+    def check_create(dirname):
+        project = project_ops.create(dirname,
+                                     make_directory=False,
+                                     name='hello',
+                                     icon='something.png',
+                                     description="Hello World",
+                                     fix_problems=True)
+        assert [] == project.problems
+        assert os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
+
+        assert sorted(list(project.env_specs.keys())) == sorted(['stuff'])
+        spec = project.env_specs['stuff']
+        assert spec.conda_packages == ('a', 'b')
+        assert spec.pip_packages == ('foo', )
+        assert spec.channels == ('bar', )
+
+    with_directory_contents(
+        {'something.png': 'not a real png',
+         "kapsel.yml": """
+name: foo
+""",
+         "environment.yml": """
+name: stuff
+dependencies:
+ - a
+ - b
+ - pip:
+   - foo
+channels:
+ - bar
+"""}, check_create)
+
+
+def test_create_no_import_environment_yml_when_not_fix_problems():
+    def check_create(dirname):
+        project_filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
+
+        project = project_ops.create(dirname,
+                                     make_directory=False,
+                                     name='hello',
+                                     icon='something.png',
+                                     description="Hello World",
+                                     fix_problems=False)
+        assert not os.path.isfile(project_filename)
+
+        assert ["Environment spec 'stuff' from environment.yml is not in kapsel.yml."] == project.problems
 
     with_directory_contents(
         {'something.png': 'not a real png',


### PR DESCRIPTION
Currently this mostly matters if you init on a project that
has a project file already; previously we'd then prompt
for things like importing environment.yml, while --yes
will cause us to do it without asking.

If there's no project file, we didn't ask anyway, but
--yes does mean we'll create the directory if needed.