### PR TITLE
when we have an environment.yml, don't create a 'default' env spec also

### DIFF
--- a/conda_kapsel/env_spec.py
+++ b/conda_kapsel/env_spec.py
@@ -179,15 +179,26 @@ def _load_environment_yml(filename):
     return EnvSpec(name=name, conda_packages=conda_packages, channels=channels, pip_packages=pip_packages)
 
 
-def _find_out_of_sync_environment_yml_spec(project_specs, filename):
-    spec = _load_environment_yml(filename)
+def _find_environment_yml_spec(directory_path):
+    filenames = ("environment.yml", "environment.yaml")
+    for filename in filenames:
+        full = os.path.join(directory_path, filename)
+        spec = _load_environment_yml(full)
+        if spec is not None:
+            return (spec, filename)
+
+    return (None, None)
+
+
+def _find_out_of_sync_environment_yml_spec(project_specs, directory_path):
+    (spec, filename) = _find_environment_yml_spec(directory_path)
 
     if spec is None:
-        return None
+        return (None, None)
 
     for existing in project_specs:
         if existing.name == spec.name and \
            existing.channels_and_packages_hash == spec.channels_and_packages_hash:
-            return None
+            return (None, None)
 
-    return spec
+    return (spec, filename)

--- a/conda_kapsel/internal/test/tmpfile_utils.py
+++ b/conda_kapsel/internal/test/tmpfile_utils.py
@@ -104,6 +104,18 @@ def with_temporary_file(func, dir=None):
         os.remove(f.name)
 
 
+def with_named_file_contents(filename, contents, func, dir=None):
+    if dir is None:
+        dir = local_tmp
+
+    with (TmpDir(prefix="test-")) as dirname:
+        full = os.path.join(dirname, filename)
+        with codecs.open(full, 'w', encoding='utf-8') as f:
+            f.write(contents)
+            f.flush()
+        return func(full)
+
+
 def with_file_contents(contents, func, dir=None):
     def with_file_object(f):
         f.write(contents.encode("UTF-8"))

--- a/conda_kapsel/test/test_project_ops.py
+++ b/conda_kapsel/test/test_project_ops.py
@@ -98,8 +98,7 @@ def test_create_imports_environment_yml():
         assert [] == project.problems
         assert os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
 
-        # TODO we shouldn't BOTH create 'default' and import 'stuff' probably
-        assert sorted(list(project.env_specs.keys())) == sorted(['stuff', 'default'])
+        assert sorted(list(project.env_specs.keys())) == sorted(['stuff'])
         spec = project.env_specs['stuff']
         assert spec.conda_packages == ('a', 'b')
         assert spec.pip_packages == ('foo', )
@@ -155,20 +154,19 @@ channels:
 
 def test_create_no_import_environment_yml_when_not_fix_problems():
     def check_create(dirname):
-        project_filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
-
         project = project_ops.create(dirname,
                                      make_directory=False,
                                      name='hello',
                                      icon='something.png',
                                      description="Hello World",
                                      fix_problems=False)
-        assert not os.path.isfile(project_filename)
-
         assert ["Environment spec 'stuff' from environment.yml is not in kapsel.yml."] == project.problems
 
     with_directory_contents(
         {'something.png': 'not a real png',
+         "kapsel.yml": """
+name: foo
+""",
          "environment.yml": """
 name: stuff
 dependencies:


### PR DESCRIPTION
The issue was that if we had an environment.yml and you did
`conda-kapsel init`, we would create an env spec from the environment.yml
and also one named `default`. Then, commands would use the useless
`default` env spec rather than the one from the environment.yml.