### PR TITLE
Add inherit_from to env specs

### DIFF
--- a/conda_kapsel/env_spec.py
+++ b/conda_kapsel/env_spec.py
@@ -253,11 +253,14 @@ class EnvSpec(object):
 
     def to_json(self):
         """Get JSON for a kapsel.yml env spec section."""
-        packages = list(self.conda_packages)
-        pip_packages = list(self.pip_packages)
+        # Note that we use _conda_packages (only the packages we
+        # introduce ourselves) rather than conda_packages
+        # (includes inherited packages).
+        packages = list(self._conda_packages)
+        pip_packages = list(self._pip_packages)
         if pip_packages:
             packages.append(dict(pip=pip_packages))
-        channels = list(self.channels)
+        channels = list(self._channels)
 
         # this is a gross, roundabout hack to get ryaml dicts that
         # have ordering... OrderedDict doesn't work because the

--- a/conda_kapsel/project_ops.py
+++ b/conda_kapsel/project_ops.py
@@ -484,6 +484,14 @@ def remove_packages(project, env_spec_name, packages):
     # and then remove it from kapsel.yml, and then see if we can
     # still prepare the project.
 
+    # TODO this should handle env spec inheritance in the same way
+    # it handles the global packages list, that is, removing a package
+    # from a spec should also remove it from its ancestors (and possibly
+    # add it to other children of those ancestors).
+    # Not doing it at the time of writing this comment because it might
+    # be nicer to rewrite this whole thing when we add version pinning
+    # anyway.
+
     failed = project.problems_status()
     if failed is not None:
         return failed

--- a/conda_kapsel/test/test_env_spec.py
+++ b/conda_kapsel/test/test_env_spec.py
@@ -246,10 +246,23 @@ def test_to_json():
                    conda_packages=['a', 'b'],
                    pip_packages=['c', 'd'],
                    channels=['x', 'y'],
-                   inherit_from_name='hi')
+                   inherit_from_names=('hi', ))
     json = spec.to_json()
 
     assert {'channels': ['x', 'y'], 'inherit_from': 'hi', 'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
+
+
+def test_to_json_multiple_inheritance():
+    spec = EnvSpec(name="foo",
+                   conda_packages=['a', 'b'],
+                   pip_packages=['c', 'd'],
+                   channels=['x', 'y'],
+                   inherit_from_names=('hi', 'hello'))
+    json = spec.to_json()
+
+    assert {'channels': ['x', 'y'],
+            'inherit_from': ['hi', 'hello'],
+            'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
 
 
 def test_diff_from():

--- a/conda_kapsel/test/test_env_spec.py
+++ b/conda_kapsel/test/test_env_spec.py
@@ -242,10 +242,14 @@ def test_find_out_of_sync_does_not_exist():
 
 
 def test_to_json():
-    spec = EnvSpec(name="foo", conda_packages=['a', 'b'], pip_packages=['c', 'd'], channels=['x', 'y'])
+    spec = EnvSpec(name="foo",
+                   conda_packages=['a', 'b'],
+                   pip_packages=['c', 'd'],
+                   channels=['x', 'y'],
+                   inherit_from_name='hi')
     json = spec.to_json()
 
-    assert {'channels': ['x', 'y'], 'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
+    assert {'channels': ['x', 'y'], 'inherit_from': 'hi', 'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
 
 
 def test_diff_from():

--- a/conda_kapsel/test/test_env_spec.py
+++ b/conda_kapsel/test/test_env_spec.py
@@ -242,11 +242,19 @@ def test_find_out_of_sync_does_not_exist():
 
 
 def test_to_json():
+    # the stuff from this parent env spec should NOT end up in the JSON
+    hi = EnvSpec(name="hi",
+                 conda_packages=['q', 'r'],
+                 pip_packages=['zoo', 'boo'],
+                 channels=['x1', 'y1'],
+                 inherit_from_names=(),
+                 inherit_from=())
     spec = EnvSpec(name="foo",
                    conda_packages=['a', 'b'],
                    pip_packages=['c', 'd'],
                    channels=['x', 'y'],
-                   inherit_from_names=('hi', ))
+                   inherit_from_names=('hi', ),
+                   inherit_from=(hi, ))
     json = spec.to_json()
 
     assert {'channels': ['x', 'y'], 'inherit_from': 'hi', 'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json

--- a/conda_kapsel/test/test_project.py
+++ b/conda_kapsel/test/test_project.py
@@ -644,11 +644,11 @@ def test_load_environments():
         assert foo.conda_packages == ('python', 'dog', 'cat', 'zebra')
         assert foo.description == "THE FOO"
         assert foo.pip_packages == ()
-        assert foo.inherit_from == ()
+        assert foo.inherit_from == (project.global_base_env_spec, )
         assert bar.conda_packages == ()
         assert bar.description == "bar"
         assert bar.pip_packages == ()
-        assert bar.inherit_from == ()
+        assert bar.inherit_from == (project.global_base_env_spec, )
 
         assert mixin.conda_packages == ('bunny', 'walrus=1.0')
         assert mixin.pip_packages == ('bear', )

--- a/conda_kapsel/yaml_file.py
+++ b/conda_kapsel/yaml_file.py
@@ -59,6 +59,26 @@ def _load_string(contents):
     return ryaml.load(contents, Loader=ryaml.RoundTripLoader)
 
 
+def _save_file(yaml, filename):
+    contents = ryaml.dump(yaml, Dumper=ryaml.RoundTripDumper)
+
+    try:
+        # This is to ensure we don't corrupt the file, even if ruamel.yaml is broken
+        ryaml.load(contents, Loader=ryaml.RoundTripLoader)
+    except YAMLError as e:  # pragma: no cover (should not happen)
+        print("ruamel.yaml bug; it failed to parse a file that it generated.", file=sys.stderr)
+        print("  the parse error was: " + str(e), file=sys.stderr)
+        print("Generated file was:", file=sys.stderr)
+        print(contents, file=sys.stderr)
+        raise RuntimeError("Bug in ruamel.yaml library; failed to parse a file that it generated: " + str(e))
+
+    if not os.path.isfile(filename):
+        # might have to make the directory
+        dirname = os.path.dirname(filename)
+        makedirs_ok_if_exists(dirname)
+    _atomic_replace(filename, contents)
+
+
 class YamlFile(object):
     """Abstract YAML file, base class for ``ProjectFile`` and ``LocalStateFile``.
 
@@ -190,23 +210,8 @@ class YamlFile(object):
         if not self._dirty:
             return
 
-        contents = ryaml.dump(self._yaml, Dumper=ryaml.RoundTripDumper)
+        _save_file(self._yaml, self.filename)
 
-        try:
-            # This is to ensure we don't corrupt the file, even if ruamel.yaml is broken
-            ryaml.load(contents, Loader=ryaml.RoundTripLoader)
-        except YAMLError as e:  # pragma: no cover (should not happen)
-            print("ruamel.yaml bug; it failed to parse a file that it generated.", file=sys.stderr)
-            print("  the parse error was: " + str(e), file=sys.stderr)
-            print("Generated file was:", file=sys.stderr)
-            print(contents, file=sys.stderr)
-            raise RuntimeError("Bug in ruamel.yaml library; failed to parse a file that it generated: " + str(e))
-
-        if not os.path.isfile(self.filename):
-            # might have to make the directory
-            dirname = os.path.dirname(self.filename)
-            makedirs_ok_if_exists(dirname)
-        _atomic_replace(self.filename, contents)
         self._change_count = self._change_count + 1
         self._dirty = False
 


### PR DESCRIPTION
An env spec can now mix in one or more other env specs:
```
env_specs:
   base:
     packages:
        - stuff
   mixin:
      packages:
         - other
   foo:
      inherit_from: base
      packages:
         - moarstuff
   doublefoo:
      inherit_from: [foo, mixin]
```
