### PR TITLE
Make the keyring dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       OS_PACKAGES=libffi ;
     fi ;
-    conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip redis pycrypto bcrypt ipython-notebook bokeh ruamel_yaml anaconda-client requests psutil $OS_PACKAGES
+    conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip redis pycrypto bcrypt notebook bokeh ruamel_yaml anaconda-client requests psutil $OS_PACKAGES
   - source activate test-environment
   - printenv | sort
   - unset CONDA_ENV_PATH # because the older conda in miniconda sets this, confusing some tests

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - beautifulsoup4
     - requests
     - anaconda-client
-    - "keyring >=9.0"
 
   run:
     - python
@@ -34,7 +33,6 @@ requirements:
     - beautifulsoup4
     - requests
     - anaconda-client
-    - "keyring >=9.0"
 
 test:
   imports:

--- a/conda_kapsel/plugins/provider.py
+++ b/conda_kapsel/plugins/provider.py
@@ -17,7 +17,6 @@ from conda_kapsel.internal import logged_subprocess
 from conda_kapsel.internal.metaclass import with_metaclass
 from conda_kapsel.internal.makedirs import makedirs_ok_if_exists
 from conda_kapsel.internal.simple_status import SimpleStatus
-import conda_kapsel.internal.keyring as keyring
 
 
 def _service_directory(local_state_file, relative_name):
@@ -407,6 +406,10 @@ class EnvVarProvider(Provider):
         config = dict()
         value = None
         if requirement.encrypted:
+            # import keyring locally because it's an optional dependency
+            # that prints a warning when it's needed but not found.
+            import conda_kapsel.internal.keyring as keyring
+
             env_prefix = self._get_env_prefix(environ)
             if env_prefix is None:
                 value = None
@@ -488,6 +491,10 @@ class EnvVarProvider(Provider):
 
     def _set_encrypted_config_values_as_strings(self, requirement, environ, local_state_file, default_env_spec_name,
                                                 overrides, values):
+        # import keyring locally because it's an optional dependency
+        # that prints a warning when it's needed but not found.
+        import conda_kapsel.internal.keyring as keyring
+
         env_prefix = self._get_env_prefix(environ)
         from_keyring = keyring.get(env_prefix, requirement.env_var)
         value_string = values.get('value', from_keyring)
@@ -571,6 +578,10 @@ class EnvVarProvider(Provider):
         #  - then the kapsel.yml default value
         local_state_override = None
         if requirement.encrypted:
+            # import keyring locally because it's an optional dependency
+            # that prints a warning when it's needed but not found.
+            import conda_kapsel.internal.keyring as keyring
+
             env_prefix = self._get_env_prefix(context.environ)
             if env_prefix is not None:
                 local_state_override = keyring.get(env_prefix, requirement.env_var)

--- a/conda_kapsel/project_ops.py
+++ b/conda_kapsel/project_ops.py
@@ -26,7 +26,6 @@ from conda_kapsel.plugins.providers.conda_env import _remove_env_path
 from conda_kapsel.internal.simple_status import SimpleStatus
 import conda_kapsel.conda_manager as conda_manager
 from conda_kapsel.internal.conda_api import parse_spec
-from conda_kapsel.internal import keyring
 
 _default_projectignore = """
 # project-local contains your personal configuration choices and state
@@ -677,6 +676,10 @@ def _unset_variable(project, env_prefix, varname, local_state):
     if len(reqs) > 0:
         req = reqs[0]
         if req.encrypted:
+            # import keyring locally because it's an optional dependency
+            # that prints a warning when it's needed but not found.
+            from conda_kapsel.internal import keyring
+
             keyring.unset(env_prefix, varname)
         else:
             local_state.unset_value(['variables', varname])
@@ -741,6 +744,10 @@ def set_variables(project, vars_and_values, env_spec_name=None):
     for varname, value in vars_and_values:
         if varname in present_vars:
             if var_reqs[varname].encrypted:
+                # import keyring locally because it's an optional dependency
+                # that prints a warning when it's needed but not found.
+                from conda_kapsel.internal import keyring
+
                 keyring.set(env_prefix, varname, value)
                 keyring_count = keyring_count + 1
             else:

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,10 @@ assert VERSION != ''
 
 PY2 = sys.version_info[0] == 2
 
-REQUIRES = ['beautifulsoup4 >= 4.3', 'tornado >= 4.2', 'keyring >= 9.0']
+REQUIRES = ['beautifulsoup4 >= 4.3', 'tornado >= 4.2']
 
-TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist']
+TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist',
+                 'keyring >= 9.0']
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')
@@ -491,8 +492,8 @@ class CondaPackageCommand(Command):
                     print("Already built for python %s at %s" % (python_version, package_path))
                 else:
                     print("Calling conda build for %s %s" % (python_version, build_arch))
-                    code = subprocess.call(['conda', 'build', '--channel', 'conda-kapsel', '--no-binstar-upload',
-                                            '--python', python_version, recipe_dir])
+                    code = subprocess.call(['conda', 'build', '--no-binstar-upload', '--python', python_version,
+                                            recipe_dir])
                     if code != 0:
                         raise Exception("Failed to build for python version " + python_version)
                     if not os.path.isfile(package_path):


### PR DESCRIPTION
The main reason is that it doesn't seem to be built for Python 2.7 or 3.6. We do need to solve that, but nobody is really using the feature it exists to support (encrypted variables) yet, so it isn't worth
getting bogged down in for the moment.
